### PR TITLE
Detect if addon using different method

### DIFF
--- a/puppet/ha-puppet/const.js
+++ b/puppet/ha-puppet/const.js
@@ -10,7 +10,8 @@ if (!optionsFile) {
   );
   process.exit(1);
 }
-export const isAddOn = optionsFile === "/data/options.json";
+// If `homeassistant_api: true` is removed from config.yaml then this detection will stop working
+export const isAddOn = process.env.SUPERVISOR_TOKEN !== undefined;
 const options = JSON.parse(readFileSync(optionsFile));
 
 export const hassUrl = isAddOn


### PR DESCRIPTION
I don't particularly like this method to detect if addon or not, but I want to be able to run a container image and mount an options.json file to `/data/options.json` to configure the container.

Open to suggestions.