### PR TITLE
Ensure grayscale images are always returned if `eink` is set

### DIFF
--- a/puppet/ha-puppet/screenshot.js
+++ b/puppet/ha-puppet/screenshot.js
@@ -405,7 +405,6 @@ export class Browser {
 
       // If eink processing was requested, output PNG with specified colors
       if (einkColors) {
-        sharpInstance = sharpInstance.toColourspace("b-w");
         if (einkColors === 2) {
           sharpInstance = sharpInstance.threshold(220, {
             greyscale: true,
@@ -416,6 +415,7 @@ export class Browser {
             });
           }
         }
+        sharpInstance = sharpInstance.toColourspace("b-w");
         if (format == "bmp") {
           sharpInstance = sharpInstance.raw();
 


### PR DESCRIPTION
Previously setting `eink` was allowed, and for `png` it reduced the color palette but never actually selected the colors at all unless `eink=2` was set. This change applies `grayscale` to all formats regardless of what `eink` level is set (as long as it is set at all)