### PR TITLE
Add support for configurable Home Assistant URL

### DIFF
--- a/puppet/README.md
+++ b/puppet/README.md
@@ -10,6 +10,12 @@ _This is a prototype, there is NO security. Anyone can access the server and mak
 
 [![ESPHome device showing a screenshot of a Home Assistant dashboard](https://raw.githubusercontent.com/balloob/home-assistant-addons/main/puppet/example/screenshot.jpg)](./example/)
 
+## Configuration
+
+- home_assistant_url: Base URL of your Home Assistant instance that the add-on browser should open when taking screenshots. Defaults to http://homeassistant:8123 when running as an add-on. You can override it if your instance is reachable via a different hostname or port (e.g., http://my-ha.local:8123 or https://example.duckdns.org).
+- access_token: Long-lived access token used to authenticate against Home Assistant.
+- keep_browser_open: If true, keeps the Chromium browser alive between requests.
+
 ## Usage
 
 Starting the add-on will launch a new server on port 10000. Any path you request will return a screenshot of that page. You will need to specify the viewport size you want.

--- a/puppet/config.yaml
+++ b/puppet/config.yaml
@@ -12,6 +12,8 @@ ports:
 options:
   access_token: ""
   keep_browser_open: false
+  home_assistant_url: "http://homeassistant:8123"
 schema:
   access_token: str
   keep_browser_open: bool
+  home_assistant_url: str

--- a/puppet/ha-puppet/const.js
+++ b/puppet/ha-puppet/const.js
@@ -14,8 +14,8 @@ export const isAddOn = optionsFile === "/data/options.json";
 const options = JSON.parse(readFileSync(optionsFile));
 
 export const hassUrl = isAddOn
-  ? "http://homeassistant:8123"
-  : options.home_assistant_url;
+  ? (options.home_assistant_url || "http://homeassistant:8123")
+  : (options.home_assistant_url || "http://localhost:8123");
 export const hassToken = options.access_token;
 export const debug = false;
 


### PR DESCRIPTION
Add support for configurable Home Assistant URL.
It's important if you have a custom internal Home Assistant URL like I have.
