### PR TITLE
Fix screenshot firing before async dashboard content finishes rendering

### DIFF
--- a/puppet/ha-puppet/http.js
+++ b/puppet/ha-puppet/http.js
@@ -340,11 +340,7 @@ class RequestHandler {
     this.busy = true;
     console.log(requestId, "Preparing next request");
     try {
-      const navigateResult = await this.browser.navigatePage({
-        ...requestParams,
-        // No unnecessary wait time, as we're just warming up
-        extraWait: 0,
-      });
+      const navigateResult = await this.browser.navigatePage(requestParams);
       console.debug(requestId, `Navigated in ${navigateResult.time} ms`);
     } catch (err) {
       console.error(requestId, "Error preparing next request", err);

--- a/puppet/ha-puppet/screenshot.js
+++ b/puppet/ha-puppet/screenshot.js
@@ -445,9 +445,6 @@ export class Browser {
           event.detail = { replace: true };
           window.dispatchEvent(event);
         }, pagePath);
-      } else {
-        // We are already on the correct page
-        defaultWait = 0;
       }
 
       this.lastRequestedPath = pagePath;


### PR DESCRIPTION
I was seeing rendering failures on a weather display. The portions depending on cached weather data always
rendered properly. The sections that sometimes required a call to a remote weather service usually worked
but were sometimes blank. Outside puppet I've never seen the failure. After the change here I haven't seen
the problem on the displays.

The readiness check (panel._loading) only reflects the HA panel router, not individual card rendering. Cards that generate content asynchronously after the panel loads, such as weather forecast charts, were not given time to complete.

Two bugs combined to cause this: prepareNextRequest forced extraWait=0 so the pre-warm never waited for async cards, and navigatePage zeroed defaultWait for same-page requests so the subsequent screenshot also skipped the wait. Now both paths apply the normal default wait, giving async content time to render before the screenshot is taken.