### PR TITLE
Fix screenshot firing before async dashboard content finishes rendering

### DIFF
--- a/puppet/ha-puppet/http.js
+++ b/puppet/ha-puppet/http.js
@@ -340,11 +340,7 @@ class RequestHandler {
     this.busy = true;
     console.log(requestId, "Preparing next request");
     try {
-      const navigateResult = await this.browser.navigatePage({
-        ...requestParams,
-        // No unnecessary wait time, as we're just warming up
-        extraWait: 0,
-      });
+      const navigateResult = await this.browser.navigatePage(requestParams);
       console.debug(requestId, `Navigated in ${navigateResult.time} ms`);
     } catch (err) {
       console.error(requestId, "Error preparing next request", err);


### PR DESCRIPTION
prepareNextRequest() forced extraWait=0 so the pre-warm never waited for async cards. Apply the normal default wait, giving async content time to render before the screenshot is taken.

I was seeing rendering failures on a weather display. The portions depending on cached weather data always
rendered properly. The sections that sometimes required a call to a remote weather service usually worked
but were sometimes blank. Outside puppet I've never seen the failure.