### PR TITLE
Puppet: fail clearly on the login screen instead of crashing

### DIFF
--- a/puppet/ha-puppet/http.js
+++ b/puppet/ha-puppet/http.js
@@ -260,7 +260,7 @@ class RequestHandler {
       } catch (err) {
         if (err instanceof CannotOpenPageError) {
           console.error(requestId, `Cannot open page: ${err.message}`);
-          response.statusCode = 404;
+          response.statusCode = err.status;
           response.end(`Cannot open page: ${err.message}`);
           return;
         }

--- a/puppet/ha-puppet/screenshot.js
+++ b/puppet/ha-puppet/screenshot.js
@@ -513,14 +513,31 @@ export class Browser {
         console.log("Timeout waiting for HA to finish loading");
       }
 
+      // If the access token is missing/invalid/expired, Home Assistant
+      // redirects to the login screen instead of the dashboard. Returning a
+      // 200 login-page screenshot is a confusing silent failure, and the
+      // language/theme evaluate() calls below crash on the login page (there is
+      // no <home-assistant> element), which kills the browser. Detect it via
+      // the auth redirect URL or the ha-authorize element and fail with a clear
+      // error instead.
+      const onLoginScreen = await page.evaluate(() => {
+        if (location.pathname.startsWith("/auth/authorize")) return true;
+        const haEl = document.querySelector("home-assistant");
+        return !!haEl?.shadowRoot?.querySelector("ha-authorize");
+      });
+      if (onLoginScreen) {
+        throw new CannotOpenPageError(401, pagePath);
+      }
+
       // Update language
       // Should really be done via localStorage.selectedLanguage
       // but that doesn't seem to work
       if (lang !== this.lastRequestedLang) {
         await page.evaluate((newLang) => {
-          document
-            .querySelector("home-assistant")
-            ._selectLanguage(newLang, false);
+          const haEl = document.querySelector("home-assistant");
+          if (haEl && typeof haEl._selectLanguage === "function") {
+            haEl._selectLanguage(newLang, false);
+          }
         }, lang || "en");
         this.lastRequestedLang = lang;
         defaultWait += 1000;
@@ -533,11 +550,14 @@ export class Browser {
       ) {
         await page.evaluate(
           ({ theme, dark }) => {
-            document.querySelector("home-assistant").dispatchEvent(
-              new CustomEvent("settheme", {
-                detail: { theme, dark },
-              }),
-            );
+            const haEl = document.querySelector("home-assistant");
+            if (haEl) {
+              haEl.dispatchEvent(
+                new CustomEvent("settheme", {
+                  detail: { theme, dark },
+                }),
+              );
+            }
           },
           { theme: theme || "", dark },
         );

--- a/puppet/ha-puppet/screenshot.js
+++ b/puppet/ha-puppet/screenshot.js
@@ -514,19 +514,12 @@ export class Browser {
       }
 
       // If the access token is missing/invalid/expired, Home Assistant
-      // redirects to the login screen instead of the dashboard. Returning a
-      // 200 login-page screenshot is a confusing silent failure, and the
-      // language/theme evaluate() calls below crash on the login page (there is
-      // no <home-assistant> element), which kills the browser. Detect it via
-      // the auth redirect URL or the ha-authorize element and fail with a clear
+      // redirects to the login screen (/auth/authorize) instead of the
+      // dashboard. Returning a 200 login-page screenshot is a confusing silent
+      // failure, so detect the redirect from the page URL and fail with a clear
       // error instead.
-      const onLoginScreen = await page.evaluate(() => {
-        if (location.pathname.startsWith("/auth/authorize")) return true;
-        const haEl = document.querySelector("home-assistant");
-        return !!haEl?.shadowRoot?.querySelector("ha-authorize");
-      });
-      if (onLoginScreen) {
-        throw new CannotOpenPageError(401, pagePath);
+      if (new URL(page.url()).pathname.startsWith("/auth/authorize")) {
+        throw new CannotOpenPageError(500, pagePath);
       }
 
       // Update language
@@ -534,10 +527,9 @@ export class Browser {
       // but that doesn't seem to work
       if (lang !== this.lastRequestedLang) {
         await page.evaluate((newLang) => {
-          const haEl = document.querySelector("home-assistant");
-          if (haEl && typeof haEl._selectLanguage === "function") {
-            haEl._selectLanguage(newLang, false);
-          }
+          document
+            .querySelector("home-assistant")
+            ._selectLanguage(newLang, false);
         }, lang || "en");
         this.lastRequestedLang = lang;
         defaultWait += 1000;
@@ -550,14 +542,11 @@ export class Browser {
       ) {
         await page.evaluate(
           ({ theme, dark }) => {
-            const haEl = document.querySelector("home-assistant");
-            if (haEl) {
-              haEl.dispatchEvent(
-                new CustomEvent("settheme", {
-                  detail: { theme, dark },
-                }),
-              );
-            }
+            document.querySelector("home-assistant").dispatchEvent(
+              new CustomEvent("settheme", {
+                detail: { theme, dark },
+              }),
+            );
           },
           { theme: theme || "", dark },
         );


### PR DESCRIPTION
If the configured `access_token` is missing, invalid, or expired, Home Assistant redirects to `/auth/authorize` (the login screen) instead of the dashboard. Today that produces a confusing 200 login-page screenshot — and worse, the language/theme `evaluate()` calls in `navigatePage` run `document.querySelector("home-assistant")._selectLanguage(...)` / `.dispatchEvent(...)` on a page that has no `<home-assistant>` element, which throws and kills the browser (the watchdog then restarts it on every request).

This detects the login screen right after the load wait — via the `/auth/authorize` URL or the `ha-authorize` element — and throws `CannotOpenPageError(401, ...)`, so the request returns a clear 404 with a message instead of a misleading image or a crash loop. The language/theme calls are also null-guarded so a not-fully-booted page can't crash the browser.

Found while using Puppet as the screenshot engine behind the [ha-mcp](https://github.com/homeassistant-ai/ha-mcp) project. Syntax-checked with `node --check`; the behavior is in production use via ha-mcp.