### PR TITLE
Puppet: capture the whole page via a WIDTHxauto viewport

### DIFF
--- a/puppet/README.md
+++ b/puppet/README.md
@@ -89,6 +89,14 @@ You can control the zoom level of the page using the `zoom` query parameter. The
 http://homeassistant.local:10000/home?viewport=1000x1000&zoom=1.3
 ```
 
+### Full page
+
+By default the screenshot is clipped to the viewport height. Add the `fullPage` parameter (no value needed) to capture the entire scrollable page instead, so a dashboard that extends below the fold is captured in one shot. The viewport width still applies; the height grows to fit the content.
+
+```
+http://homeassistant.local:10000/home?viewport=1000x1000&fullPage
+```
+
 ### Output formats
 
 By default, the output format is PNG. You can request a JPEG, WebP or BMP image by adding the `format=jpeg`, `format=webp`, `format=bmp` query parameter:

--- a/puppet/README.md
+++ b/puppet/README.md
@@ -91,10 +91,10 @@ http://homeassistant.local:10000/home?viewport=1000x1000&zoom=1.3
 
 ### Full page
 
-By default the screenshot is clipped to the viewport height. Add the `fullPage` parameter (no value needed) to capture the entire scrollable page instead, so a dashboard that extends below the fold is captured in one shot. The viewport width still applies; the height grows to fit the content.
+By default the screenshot is clipped to the viewport height. Set the height to `auto` in the `viewport` parameter to capture the entire scrollable page instead, so a dashboard that extends below the fold is captured in one shot. The width still applies; the height grows to fit the content, capped at 4000px so a very long page can't produce a runaway image.
 
 ```
-http://homeassistant.local:10000/home?viewport=1000x1000&fullPage
+http://homeassistant.local:10000/home?viewport=1000xauto
 ```
 
 ### Output formats

--- a/puppet/ha-puppet/html/index.html
+++ b/puppet/ha-puppet/html/index.html
@@ -142,6 +142,20 @@
                   --tw-ring-color: var(--ha-blue);
                 "
               />
+              <div class="flex items-center mt-2">
+                <input
+                  type="checkbox"
+                  id="auto_height"
+                  class="h-4 w-4 border-gray-300 rounded"
+                  style="
+                    color: var(--ha-blue);
+                    --tw-ring-color: var(--ha-blue);
+                  "
+                />
+                <label for="auto_height" class="ml-2 block text-sm text-gray-700"
+                  >Auto height (capture full page, max 4000px)</label
+                >
+              </div>
             </div>
 
             <!-- Next -->
@@ -640,6 +654,27 @@
     </div>
 
     <script>
+      // Effective viewport height for the URL: the literal "auto" when the
+      // auto-height box is checked, otherwise the numeric height field.
+      function getViewportHeight() {
+        return document.getElementById("auto_height").checked
+          ? "auto"
+          : document.getElementById("height").value;
+      }
+
+      // Apply a viewport height string (a number or "auto") to the form,
+      // toggling the auto-height checkbox and disabling the number field to
+      // match. A numeric value is preserved so unchecking auto restores it.
+      function setViewportHeight(height) {
+        const isAuto = String(height).toLowerCase() === "auto";
+        const heightEl = document.getElementById("height");
+        document.getElementById("auto_height").checked = isAuto;
+        heightEl.disabled = isAuto;
+        if (!isAuto && height !== undefined && height !== "") {
+          heightEl.value = height;
+        }
+      }
+
       // Save settings to localStorage
       function saveSettings() {
         const settings = {
@@ -647,6 +682,7 @@
           path: document.getElementById("path").value,
           width: document.getElementById("width").value,
           height: document.getElementById("height").value,
+          auto_height: document.getElementById("auto_height").checked,
           format: document.getElementById("format").value,
           theme: document.getElementById("theme").value,
           dark: document.getElementById("dark").checked,
@@ -680,6 +716,10 @@
             document.getElementById("width").value = settings.width;
           if (settings.height !== undefined)
             document.getElementById("height").value = settings.height;
+          if (settings.auto_height !== undefined) {
+            document.getElementById("auto_height").checked = settings.auto_height;
+            document.getElementById("height").disabled = settings.auto_height;
+          }
           if (settings.format !== undefined)
             document.getElementById("format").value = settings.format;
           if (settings.theme !== undefined)
@@ -725,12 +765,12 @@
           document.getElementById("path").value = urlParams.get("path");
         }
 
-        // Parse viewport (widthxheight)
+        // Parse viewport (widthxheight, or widthxauto)
         const viewport = urlParams.get("viewport");
         if (viewport) {
           const [width, height] = viewport.split("x");
           if (width) document.getElementById("width").value = width;
-          if (height) document.getElementById("height").value = height;
+          if (height) setViewportHeight(height);
         }
 
         // Load other parameters
@@ -780,7 +820,7 @@
         const device = document.getElementById("device").value;
         const path = document.getElementById("path").value || "/";
         const width = document.getElementById("width").value;
-        const height = document.getElementById("height").value;
+        const height = getViewportHeight();
         const format = document.getElementById("format").value;
         const theme = document.getElementById("theme").value;
         const dark = document.getElementById("dark").checked;
@@ -930,12 +970,12 @@
             document.getElementById("path").value = pathname;
           }
 
-          // Parse viewport (widthxheight)
+          // Parse viewport (widthxheight, or widthxauto)
           const viewport = urlParams.get("viewport");
           if (viewport) {
             const [width, height] = viewport.split("x");
             if (width) document.getElementById("width").value = width;
-            if (height) document.getElementById("height").value = height;
+            if (height) setViewportHeight(height);
           }
 
           // Load other parameters
@@ -1031,7 +1071,7 @@
         const device = document.getElementById("device").value;
         const path = document.getElementById("path").value || "/";
         const width = document.getElementById("width").value;
-        const height = document.getElementById("height").value;
+        const height = getViewportHeight();
         const format = document.getElementById("format").value;
         const theme = document.getElementById("theme").value;
         const dark = document.getElementById("dark").checked;
@@ -1347,7 +1387,7 @@
           document.getElementById("width").value = device.width;
         }
         if (device.height !== undefined) {
-          document.getElementById("height").value = device.height;
+          setViewportHeight(device.height);
         }
         if (device.colors !== undefined) {
           document.getElementById("colors").value = device.colors;
@@ -1439,6 +1479,12 @@
       // Note: loadPreview() is called by the generic select change listener below
       document.getElementById("device").addEventListener("change", () => {
         onDeviceChange();
+      });
+
+      // Disable the height field while auto height is on (URL/preview refresh is
+      // handled by the generic input listeners above).
+      document.getElementById("auto_height").addEventListener("change", (e) => {
+        document.getElementById("height").disabled = e.target.checked;
       });
 
       // Load settings and initialize on page load

--- a/puppet/ha-puppet/http.js
+++ b/puppet/ha-puppet/http.js
@@ -7,6 +7,10 @@ import { loadDevicesConfig, getDeviceConfig } from "./devices.js";
 
 // Maximum number of next requests to keep in memory
 const MAX_NEXT_REQUESTS = 100;
+// Initial viewport height (px) used to render a "WIDTHxauto" request before the
+// full page height is measured. Kept modest so short pages don't gain trailing
+// whitespace; taller content still renders and is captured via the clip.
+const AUTO_RENDER_HEIGHT = 800;
 const BROWSER_TIMEOUT = 30_000; // Timeout for browser inactivity in milliseconds
 
 class RequestHandler {
@@ -111,11 +115,20 @@ class RequestHandler {
         extraWait = undefined;
       }
 
-      // Get viewport - use device config as default if device is specified
+      // Get viewport - use device config as default if device is specified.
+      // The height may be the literal "auto" (e.g. "1000xauto") to capture the
+      // whole scrollable page; the captured height is then derived from the
+      // rendered content and capped (see MAX_AUTO_HEIGHT in screenshot.js).
+      let autoHeight = false;
       let viewportParams;
       const viewportQuery = requestUrl.searchParams.get("viewport");
       if (viewportQuery) {
-        viewportParams = viewportQuery.split("x").map((n) => parseInt(n));
+        const [widthStr, heightStr] = viewportQuery.split("x");
+        autoHeight = (heightStr || "").toLowerCase() === "auto";
+        viewportParams = [
+          parseInt(widthStr),
+          autoHeight ? AUTO_RENDER_HEIGHT : parseInt(heightStr),
+        ];
       } else if (deviceConfig) {
         viewportParams = [deviceConfig.width, deviceConfig.height];
       } else {
@@ -190,9 +203,6 @@ class RequestHandler {
 
       const invert = requestUrl.searchParams.has("invert");
 
-      // Capture the whole scrollable page instead of just the viewport.
-      const fullPage = requestUrl.searchParams.has("fullPage");
-
       let format = requestUrl.searchParams.get("format") || "png";
       if (!["png", "jpeg", "webp", "bmp"].includes(format)) {
         format = "png";
@@ -239,7 +249,7 @@ class RequestHandler {
         paletteColors,
         dithering,
         invert,
-        fullPage,
+        autoHeight,
         zoom,
         format,
         bmpMode,

--- a/puppet/ha-puppet/http.js
+++ b/puppet/ha-puppet/http.js
@@ -190,6 +190,9 @@ class RequestHandler {
 
       const invert = requestUrl.searchParams.has("invert");
 
+      // Capture the whole scrollable page instead of just the viewport.
+      const fullPage = requestUrl.searchParams.has("fullPage");
+
       let format = requestUrl.searchParams.get("format") || "png";
       if (!["png", "jpeg", "webp", "bmp"].includes(format)) {
         format = "png";
@@ -236,6 +239,7 @@ class RequestHandler {
         paletteColors,
         dithering,
         invert,
+        fullPage,
         zoom,
         format,
         bmpMode,

--- a/puppet/ha-puppet/screenshot.js
+++ b/puppet/ha-puppet/screenshot.js
@@ -6,6 +6,10 @@ import { CannotOpenPageError } from "./error.js";
 
 const HEADER_HEIGHT = 56;
 
+// Cap (px) for an auto-height ("WIDTHxauto") screenshot so a very long
+// dashboard can't produce a runaway image. Content taller than this is clipped.
+const MAX_AUTO_HEIGHT = 4000;
+
 // Dithering algorithms
 function applyDithering(data, width, height, palette, channels = 4, algorithm = "atkinson", paletteColors = null) {
   // Convert hex colors to RGB
@@ -562,7 +566,7 @@ export class Browser {
     }
   }
 
-  async screenshotPage({ viewport, colors, paletteColors, dithering, invert, zoom, format, rotate, fullPage = false, bmpMode = "color" }) {
+  async screenshotPage({ viewport, colors, paletteColors, dithering, invert, zoom, format, rotate, autoHeight = false, bmpMode = "color" }) {
     let start = new Date();
     if (this.busy) {
       throw new Error("Browser is busy");
@@ -575,15 +579,20 @@ export class Browser {
       const page = await this.getPage();
 
       // Default: clip to the viewport (minus the cropped header). With
-      // fullPage, clip to the document's full scroll height so a dashboard that
-      // extends below the fold is captured in one shot — still cropping the
-      // header. (Puppeteer renders beyond the viewport for the taller clip.)
+      // autoHeight (a "WIDTHxauto" viewport), clip to the document's full scroll
+      // height instead so a dashboard that extends below the fold is captured in
+      // one shot — still cropping the header, and capped at MAX_AUTO_HEIGHT so a
+      // very long page can't run away. (Puppeteer renders beyond the viewport
+      // for the taller clip.)
       let clipHeight = viewport.height - headerHeight;
-      if (fullPage) {
+      if (autoHeight) {
         const scrollHeight = await page.evaluate(
           () => document.documentElement.scrollHeight,
         );
-        clipHeight = Math.max(scrollHeight - headerHeight, 1);
+        clipHeight = Math.min(
+          Math.max(scrollHeight - headerHeight, 1),
+          MAX_AUTO_HEIGHT,
+        );
       }
 
       let image = await page.screenshot({

--- a/puppet/ha-puppet/screenshot.js
+++ b/puppet/ha-puppet/screenshot.js
@@ -562,7 +562,7 @@ export class Browser {
     }
   }
 
-  async screenshotPage({ viewport, colors, paletteColors, dithering, invert, zoom, format, rotate, bmpMode = "color" }) {
+  async screenshotPage({ viewport, colors, paletteColors, dithering, invert, zoom, format, rotate, fullPage = false, bmpMode = "color" }) {
     let start = new Date();
     if (this.busy) {
       throw new Error("Browser is busy");
@@ -574,13 +574,25 @@ export class Browser {
     try {
       const page = await this.getPage();
 
+      // Default: clip to the viewport (minus the cropped header). With
+      // fullPage, clip to the document's full scroll height so a dashboard that
+      // extends below the fold is captured in one shot — still cropping the
+      // header. (Puppeteer renders beyond the viewport for the taller clip.)
+      let clipHeight = viewport.height - headerHeight;
+      if (fullPage) {
+        const scrollHeight = await page.evaluate(
+          () => document.documentElement.scrollHeight,
+        );
+        clipHeight = Math.max(scrollHeight - headerHeight, 1);
+      }
+
       let image = await page.screenshot({
         type: "png",
         clip: {
           x: 0,
           y: headerHeight,
           width: viewport.width,
-          height: viewport.height - headerHeight,
+          height: clipHeight,
         },
       });
 


### PR DESCRIPTION
By default the screenshot is clipped to the viewport height, so a dashboard that scrolls past the viewport is cut off below the fold. This lets you set the height to `auto` in the `viewport` string (e.g. `viewport=1000xauto`): the screenshot then clips to the document's `scrollHeight` instead of a fixed height — still cropping the header — so the entire scrollable page is captured in one request. The captured height is capped at 4000px so a very long page can't produce a runaway image.

The web UI gets an "Auto height" checkbox alongside the viewport fields, and the README documents the `WIDTHxauto` syntax.

Found useful while using Puppet as the screenshot engine behind the [ha-mcp](https://github.com/homeassistant-ai/ha-mcp) project. Syntax-checked with `node --check`.
