### PR TITLE
Update screenshot.js to include prefers-reduced-motion

### DIFF
--- a/puppet/ha-puppet/screenshot.js
+++ b/puppet/ha-puppet/screenshot.js
@@ -326,6 +326,10 @@ export class Browser {
     });
     const page = await browser.newPage();
 
+    await page.emulateMediaFeatures([
+      {name: 'prefers-reduced-motion', value: 'reduce'},
+    ]);
+
     // Route all log messages from browser to our add-on log
     // https://pptr.dev/api/puppeteer.pageevents
     page


### PR DESCRIPTION
Hi, 

Thanks for your work on this addon, really saved me some time when setting up a dashboard for my eink screen!

This PR sets prefers-reduced-motion=reduce on the puppeteer page before taking a screenshot. This makes animations HA not run (or at least dramatically reduces their execution time), and lowers the risk of the screenshot coming out before animations complete. The existing wait time option does not always fix this for me.

E.g. screenshot before animation:
<img width="800" height="480" alt="037694d9-5ac0-4bea-bfb4-bca9e44d0f4f" src="https://github.com/user-attachments/assets/ccc9a88d-473e-4306-8ac6-f8798635e916" />

Thanks for considering this PR!